### PR TITLE
Add rule for COIN-OR Ipopt

### DIFF
--- a/rules/ipopt.json
+++ b/rules/ipopt.json
@@ -1,0 +1,19 @@
+  {
+    "patterns": ["\\bipopt\\b"],
+    "dependencies": [
+      {
+        "packages": ["coinor-libipopt-dev"],
+        "constraints": [
+          { "os": "linux", "distribution": "ubuntu" },
+          { "os": "linux", "distribution": "debian" }
+        ]
+      },
+      {
+        "packages": ["coin-or-Ipopt-devel"],
+        "constraints": [
+          { "os": "linux", "distribution": "fedora" }
+        ]
+      }
+    ]
+  }
+


### PR DESCRIPTION
Maps the `Ipopt` SystemRequirements token to:

  - Debian/Ubuntu: coinor-libipopt-dev
  - Fedora:        coin-or-Ipopt-devel

There's no `Ipopt` rule yet, so `pak `can't resolve the dependency and source builds of `Ipopt`-based R packages fail at configure. This adds one, following the existing `coin-or-clp` and `coinor-symphony` rules.

PS. This is needed for my work on adding `Ipopt` nonlinear solver for an updated version of [`CVXR`](https://cvxr.rbind.io).  I plan to put this solver package for `Ipopt` on r-universe.dev only BTW.  

Thank you.